### PR TITLE
Disable preload in ipfs config

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,6 @@
 // Configuration for IPFS instance
 const ipfsConfig = {
+  preload: { enabled: false }, // Prevents large data transfers
   repo: '/orbitdb/examples/todomvc/ipfs/0.27.0',
   EXPERIMENTAL: {
     pubsub: true,


### PR DESCRIPTION
This pull request disables the preload setting in the ipfs config. Without this change, large amounts of data get sent to the ipfs preload nodes.

I tested this on my local PC with a clean database. With preload enabled there are data transfers for every change in the database: (exponentially increasing in size)
![image](https://user-images.githubusercontent.com/66420755/109197826-c6929c80-779d-11eb-8759-cf476994737e.png)

These transfers completely disappear when `preload: { enabled: false }` is added to the ipfs config.
